### PR TITLE
fix: replaced depreacted field "basePathName"

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,33 +1,33 @@
-import { defineConfig } from "vite";
-import { qwikVite } from "@builder.io/qwik/optimizer";
-import { qwikCity } from "@builder.io/qwik-city/vite";
-import { imagetools } from "vite-imagetools";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from 'vite';
+import { qwikVite } from '@builder.io/qwik/optimizer';
+import { qwikCity } from '@builder.io/qwik-city/vite';
+import { imagetools } from 'vite-imagetools';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
-import { SITE } from "./src/config.mjs";
+import { SITE } from './src/config.mjs';
 
-const path = require("path");
+const path = require('path');
 
 export default defineConfig(() => {
-  return {
-    plugins: [
-      qwikCity({
-        basePathname: SITE.basePathname,
-        trailingSlash: SITE.trailingSlash,
-      }),
-      qwikVite(),
-      tsconfigPaths(),
-      imagetools(),
-    ],
-    preview: {
-      headers: {
-        "Cache-Control": "public, max-age=600",
-      },
-    },
-    resolve: {
-      alias: {
-        "~": path.resolve(__dirname, "./src"),
-      },
-    },
-  };
+    return {
+        base: SITE.basePathname,
+        plugins: [
+            qwikCity({
+                trailingSlash: SITE.trailingSlash,
+            }),
+            qwikVite(),
+            tsconfigPaths(),
+            imagetools(),
+        ],
+        preview: {
+            headers: {
+                'Cache-Control': 'public, max-age=600',
+            },
+        },
+        resolve: {
+            alias: {
+                '~': path.resolve(__dirname, './src'),
+            },
+        },
+    };
 });


### PR DESCRIPTION
"basePathname" has now been marked as deprecated and is replaced by using the "base" property in the vite config.

This deprecation was introduced here: https://github.com/BuilderIO/qwik/pull/3093