### PR TITLE
Theme toggle reliability 

### DIFF
--- a/src/components/core/ToggleTheme.tsx
+++ b/src/components/core/ToggleTheme.tsx
@@ -1,4 +1,4 @@
-import { component$, useStore, useTask$ } from "@builder.io/qwik";
+import { component$, useStore, useVisibleTask$ } from "@builder.io/qwik";
 
 import { IconSun } from "~/components/icons/IconSun";
 import { IconMoon } from "../icons/IconMoon";
@@ -15,17 +15,11 @@ export default component$((props: ItemProps) => {
       undefined,
   });
 
-  useTask$(() => {
-    if  (!(typeof window !== "undefined" && window?.localStorage)) {
-      return;
-    }
-  
+  useVisibleTask$(() => {
     store.theme =
-      window.localStorage.theme === "dark" ||
-      (!("theme" in window.localStorage) &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ? "dark"
-        : "light";
+      document.documentElement.classList.contains("dark")
+      ? "dark"
+      : "light";
   });
 
   return (


### PR DESCRIPTION
I noticed when using this template that in certain cases the theme toggle didn't work correctly on the first click because the logic didn't account for when the store default was `undefined` - the simplest way I found to fix this was to simply determine the current state post-page-load (via `useVisibleTask$`) by checking whether `"dark"` was present in the class list.

Happy to make changes if you have any feedback, and thank you for your great work on this template!